### PR TITLE
chore(docs): remove mentions of governant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ GET <key>
 
 # Secret Manager
 
-This service uses Vault for syncing secrets to our app. The base path is `secret/governant`.
+This service uses Vault for syncing secrets to our app.
 
 The following structure is expected:
 
-- `secret/governant/{environment}/app_tokens`
-- `secret/governant/{environment}/settings`
+- `secret/{VAULT_NAMESPACE}/{environment}/app_tokens`
+- `secret/{VAULT_NAMESPACE}/{environment}/settings`
 
 ## Contributing
 

--- a/security/secrets/vault.go
+++ b/security/secrets/vault.go
@@ -1,10 +1,5 @@
 package secrets
 
-// This package expects the following structure for Vault.
-// /secret/governant/app_tokens
-// /secret/governant/settings
-// @TODO: Migrate to IAM naming
-
 import (
 	"errors"
 	"fmt"


### PR DESCRIPTION
Governant was old naming of the project. Mentions are now redundant.

closes #15 