### PR TITLE
Docker: cache dependencies during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM golang:1.12.7 as builder
 RUN mkdir /app
-COPY . /app/
 WORKDIR /app
+
+# This step is done separately than `COPY . /app/` in order to
+# cache dependencies.
+COPY go.mod go.sum Makefile /app/
+RUN make install_deps
+
+COPY . /app/
 ARG CI_COMMIT_SHORT_SHA
 RUN make build
 


### PR DESCRIPTION
This shouldn't impact the CI, as CircleCI has layer caching disabled by default (it's a premium feature), but should make building images and e2e much faster locally.