### PR TITLE
docs: add basic Hugo setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .DS_Store
 .env.yaml
 
+### Hugo
+_gen
+
 ### GO
 
 # Binaries for programs and plugins

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "www/themes/cupper-hugo-theme"]
+	path = www/themes/cupper-hugo-theme
+	url = https://github.com/zwbetz-gh/cupper-hugo-theme.git

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ install_deps:
 	go mod download
 	GO111MODULE=off go get github.com/cespare/reflex
 	GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go
+	curl -sfL https://install.goreleaser.com/github.com/gohugoio/hugo.sh | sh
 
 start:
 	go run cmd/main.go
@@ -65,3 +66,7 @@ coala:
 
 proto:
 	protoc --go_out=plugins=grpc:. ./api/grpc/v1/iam.proto
+
+hugo:
+	# -D shows draft pages as well
+	hugo server www -D

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ The following structure is expected:
 - Run `make test/ci`, `make lint`, and [`make e2e`](tests/e2e/README.md) before pushing changes.
 - Commit messages should be at most 72 characters long.
 - Commit messages should start with the scope of the changes introduced by the commit.
+
+## Contributing to documentation
+
+Run `make hugo`. This will launch the hugo server for development.

--- a/www/archetypes/default.md
+++ b/www/archetypes/default.md
@@ -1,0 +1,5 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---

--- a/www/config.toml
+++ b/www/config.toml
@@ -1,0 +1,5 @@
+baseURL = "https://kiwicom.github.io/iam/"
+languageCode = "en-us"
+title = "Kiwi IAM documentation"
+theme = "cupper-hugo-theme"
+sectionPagesMenu = "main"

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -1,0 +1,9 @@
+---
+title: ""
+date: 2019-07-23T12:15:33+02:00
+draft: false
+---
+
+# Kiwi IAM
+
+Kiwi IAM documentation will go here. Right now it's just empty, but will be filled with documentation soon.


### PR DESCRIPTION
- adds command to download hugo binary
- adds command to start Hugo development server
- adds basic hugo setup with Cupper theme