### PR TITLE
Docs: add hugo publish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 ### Hugo
 _gen
+bin
+public
 
 ### GO
 

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,8 @@ endif
 coala:
 	docker run -v "$(shell pwd)":/app -v /tmp/coala-cache:/cache --workdir=/app coala/base:0.11 coala -a -n -j 4
 
--include ./test/e2e/e2e.mk
-
 proto:
 	protoc --go_out=plugins=grpc:. ./api/grpc/v1/iam.proto
 
-hugo:
-	# -D shows draft pages as well
-	hugo server www -D
+-include ./test/e2e/e2e.mk
+-include ./www/docs.mk

--- a/www/docs.mk
+++ b/www/docs.mk
@@ -1,0 +1,6 @@
+docs/build:
+	cd www && ./publish.sh
+
+docs/serve:
+	# -D shows draft pages as well
+	cd www && hugo server -D

--- a/www/publish.sh
+++ b/www/publish.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+if [ "`git status -s`" ]
+then
+    echo "The working directory is dirty. Please commit any pending changes."
+    exit 1;
+fi
+
+echo "Deleting old publication"
+rm -rf public
+mkdir public
+git worktree prune
+rm -rf .git/worktrees/public/
+
+echo "Checking out gh-pages branch into public"
+git worktree add -B gh-pages public origin/gh-pages
+
+echo "Removing existing files"
+rm -rf public/*
+
+echo "Generating site"
+hugo
+
+echo "Updating gh-pages branch"
+cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
+
+#echo "Pushing to github"
+git push --all
+


### PR DESCRIPTION
The `publish.sh` script is taken from the [hugo docs](https://gohugo.io/hosting-and-deployment/hosting-on-github/#put-it-into-a-script-1). It "mounts" the `gh-pages` branch in the public folder, generates the static files, and creates a new commit on `gh-pages`  with the new assets.