### PR TITLE
Chore: clean makefiles and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ The following structure is expected:
 
 ## Contributing
 
-- Run `make test/ci`, `make lint`, and [`make e2e`](tests/e2e/README.md) before pushing changes.
+- Run `make test/all` before pushing changes.
 - Commit messages should be at most 72 characters long.
 - Commit messages should start with the scope of the changes introduced by the commit.
 
 ## Contributing to documentation
 
-Run `make hugo`. This will launch the hugo server for development.
+Run `make install_hugo` to install hugo, and `make docs/serve` to launch the
+hugo server for development.

--- a/www/docs.mk
+++ b/www/docs.mk
@@ -1,3 +1,6 @@
+install_hugo:
+	curl -sfL https://install.goreleaser.com/github.com/gohugoio/hugo.sh | sh
+
 docs/publish:
 	cd www && ./publish.sh
 


### PR DESCRIPTION
I also moved the hugo installation to a separate step on the docs makefile, because we're not using it in the CI, and locally it only needs to be run once, so at the moment it's just slowing down the `install_deps` step on pipelines. 