### PR TITLE
chore: pin version of commitsar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
 
   validate-commits:
     docker:
-      - image: commitsar/commitsar
+      - image: commitsar/commitsar:0.2.0
     steps:
       - checkout
       - run: commitsar


### PR DESCRIPTION
- to prevent random failures it's better to use pinned versions