### PR TITLE
docs: improve the github pages runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
           command: |
             cd www
             npm i
-            hugo mod get
       - run:
           name: Set author of the commit
           command: |


### PR DESCRIPTION
- hugo mod get attaches newly released tags to go.sum which fails the publish script