### PR TITLE
fix: use email instead of employeeNumber as user ID

### DIFF
--- a/internal/services/okta/controller.go
+++ b/internal/services/okta/controller.go
@@ -124,7 +124,7 @@ func (c *Client) AddPermissions(user *User, service string) error {
 	}
 
 	for groupName, users := range cachedGroupMemberships {
-		if users[user.EmployeeNumber] {
+		if users[user.Email] {
 			user.Permissions = append(user.Permissions, groupName)
 		}
 	}

--- a/internal/services/okta/group_memberships.go
+++ b/internal/services/okta/group_memberships.go
@@ -42,7 +42,7 @@ func (c *Client) fetchGroupMembership(groupID string) ([]string, error) {
 
 		users := make([]string, len(resources))
 		for i := range resources {
-			users[i] = resources[i].Profile.EmployeeNumber
+			users[i] = resources[i].Profile.Email
 		}
 
 		allUsers = append(allUsers, users...)


### PR DESCRIPTION
As discussed internally, it doesn't make sense to use two different IDs for users, so we'll use emails everywhere. 