### PR TITLE
fix(permissions): return error on group re-sync

### DIFF
--- a/api/rest/route_permissions.go
+++ b/api/rest/route_permissions.go
@@ -43,6 +43,11 @@ func getServicesPermissions(client permissionDataService, tracer *monitoring.Tra
 		}
 
 		permissions, err := getPermissions()
+		if err == okta.ErrNotReady {
+			w.Header().Add("Retry-After", "30")
+			http.Error(w, "Data not ready", http.StatusServiceUnavailable)
+			return
+		}
 		if err != nil {
 			http.Error(w, "Service unavailable", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Currently in some (rare) cases if a request is sent it will be kept open while we re-sync all groups. This always leads to a timeout of the request, since syncing groups takes a couple of minutes. 

A better solution is to return an error with a `Retry-After` header, so the client can decide how to act in this situation (whether to also return an error, proceed without this data, or wait and send a new request).