### PR TITLE
Feat/rest rewrite

### DIFF
--- a/api/rest/v1/docs.go
+++ b/api/rest/v1/docs.go
@@ -1,4 +1,4 @@
 /*Package rest houses all routes and server logic for all communication over REST.
 *
-*/
+ */
 package rest

--- a/api/rest/v1/docs.go
+++ b/api/rest/v1/docs.go
@@ -1,0 +1,4 @@
+/*Package rest houses all routes and server logic for all communication over REST.
+*
+*/
+package rest

--- a/api/rest/v1/handle_healthcheck.go
+++ b/api/rest/v1/handle_healthcheck.go
@@ -6,7 +6,7 @@ import (
 )
 
 // handleHealthcheck is a route for healthcheck
-func (s *server) handleHealthcheck() http.HandlerFunc {
+func (s *Server) handleHealthcheck() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var message = "Ok"
 		_, err := w.Write([]byte(message))

--- a/api/rest/v1/handle_healthcheck.go
+++ b/api/rest/v1/handle_healthcheck.go
@@ -1,0 +1,18 @@
+package rest
+
+import (
+	"log"
+	"net/http"
+)
+
+// handleHealthcheck is a route for healthcheck
+func (s *server) handleHealthcheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var message = "Ok"
+		_, err := w.Write([]byte(message))
+
+		if err != nil {
+			log.Println("[ERROR] Failed to return healthcheck: ", err)
+		}
+	}
+}

--- a/api/rest/v1/handle_healthcheck_test.go
+++ b/api/rest/v1/handle_healthcheck_test.go
@@ -1,0 +1,26 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheck(t *testing.T) {
+	s := server{}
+
+	req, err := http.NewRequest("GET", "/healthcheck", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+
+	handler := s.handleHealthcheck()
+
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	body := w.Body.String()
+	assert.Equal(t, "Ok", body)
+}

--- a/api/rest/v1/handle_healthcheck_test.go
+++ b/api/rest/v1/handle_healthcheck_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	s := server{}
+	s := Server{}
 
 	req, err := http.NewRequest("GET", "/healthcheck", nil)
 	assert.NoError(t, err)

--- a/api/rest/v1/handle_hello.go
+++ b/api/rest/v1/handle_hello.go
@@ -6,7 +6,7 @@ import (
 )
 
 // handleHello is a route for HelloWorld
-func (s *server) handleHello() http.HandlerFunc {
+func (s *Server) handleHello() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		message := "42"
 		_, err := w.Write([]byte(message))

--- a/api/rest/v1/handle_hello.go
+++ b/api/rest/v1/handle_hello.go
@@ -1,0 +1,17 @@
+package rest
+
+import (
+	"log"
+	"net/http"
+)
+
+// handleHello is a route for HelloWorld
+func (s *server) handleHello() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		message := "42"
+		_, err := w.Write([]byte(message))
+		if err != nil {
+			log.Println("Hello World failed: ", err)
+		}
+	}
+}

--- a/api/rest/v1/handle_teams.go
+++ b/api/rest/v1/handle_teams.go
@@ -7,7 +7,7 @@ import (
 	"github.com/getsentry/raven-go"
 )
 
-func (s *server) handleTeamsGET() http.HandlerFunc {
+func (s *Server) handleTeamsGET() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		teams, err := s.oktaService.GetTeams()
 		if err != nil {

--- a/api/rest/v1/handle_teams.go
+++ b/api/rest/v1/handle_teams.go
@@ -1,0 +1,25 @@
+package rest
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/getsentry/raven-go"
+)
+
+func (s *server) handleTeamsGET() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		teams, err := s.oktaService.GetTeams()
+		if err != nil {
+			http.Error(w, "Service unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		je := json.NewEncoder(w)
+		if err := je.Encode(teams); err != nil {
+			log.Println("[ERROR]", err.Error())
+			raven.CaptureError(err, nil)
+		}
+	}
+}

--- a/api/rest/v1/handle_teams_test.go
+++ b/api/rest/v1/handle_teams_test.go
@@ -20,7 +20,7 @@ func (tg *mockTeamsGetter) GetTeams() (map[string]int, error) {
 }
 
 func TestInternalError(t *testing.T) {
-	s := server{}
+	s := Server{}
 	errMessage := "internal error that shouldn't be exposed"
 	tg := &mockTeamsGetter{}
 	s.oktaService = tg
@@ -39,7 +39,7 @@ func TestInternalError(t *testing.T) {
 }
 
 func TestGetTeams(t *testing.T) {
-	s := server{}
+	s := Server{}
 	tg := &mockTeamsGetter{}
 	tg.On("GetTeams").Return(map[string]int{"team1": 3, "team2": 1, "team3": 1}, nil)
 	s.oktaService = tg

--- a/api/rest/v1/handle_teams_test.go
+++ b/api/rest/v1/handle_teams_test.go
@@ -1,0 +1,58 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockTeamsGetter struct {
+	mock.Mock
+}
+
+func (tg *mockTeamsGetter) GetTeams() (map[string]int, error) {
+	args := tg.Called()
+	return args.Get(0).(map[string]int), args.Error(1)
+}
+
+func TestInternalError(t *testing.T) {
+	s := server{}
+	errMessage := "internal error that shouldn't be exposed"
+	tg := &mockTeamsGetter{}
+	s.oktaService = tg
+	tg.On("GetTeams").Return(map[string]int{}, errors.New(errMessage))
+
+	request, _ := http.NewRequest("GET", "/", nil)
+
+	w := httptest.NewRecorder()
+
+	handler := s.handleTeamsGET()
+	handler.ServeHTTP(w, request)
+
+	assert.Equal(t, 500, w.Code)
+	assert.NotEqual(t, errMessage, w.Body.String())
+	tg.AssertExpectations(t)
+}
+
+func TestGetTeams(t *testing.T) {
+	s := server{}
+	tg := &mockTeamsGetter{}
+	tg.On("GetTeams").Return(map[string]int{"team1": 3, "team2": 1, "team3": 1}, nil)
+	s.oktaService = tg
+
+	request, _ := http.NewRequest("GET", "/", nil)
+
+	w := httptest.NewRecorder()
+
+	handler := s.handleTeamsGET()
+	handler.ServeHTTP(w, request)
+
+	var expected = "{\"team1\":3,\"team2\":1,\"team3\":1}\n"
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, expected, w.Body.String())
+	tg.AssertExpectations(t)
+}

--- a/api/rest/v1/middleware_security.go
+++ b/api/rest/v1/middleware_security.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"log"
+	"net/http"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/kiwicom/iam/api"
+	"github.com/kiwicom/iam/internal/monitoring"
+	"github.com/kiwicom/iam/internal/security"
+)
+
+// AuthWrapper wraps a router to validate the authentication token
+func (s *server) middlewareSecurity(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := s.checkAuth(r)
+		if err != nil {
+			if apiErr, ok := err.(api.Error); ok {
+				http.Error(w, apiErr.Message, apiErr.Code)
+			} else {
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+			}
+
+			log.Println("[ERROR]", err.Error())
+			return
+		}
+
+		// Delegate request to the given handle
+		h(w, r)
+	}
+}
+
+// checkAuth checks if user has proper token + user agent
+func (s *server) checkAuth(r *http.Request) error {
+	requestToken, err := security.GetToken(r.Header.Get("Authorization"))
+	if err != nil {
+		return api.Error{Message: "Use the Bearer {token} authorization scheme", Code: http.StatusUnauthorized}
+	}
+	userAgent := r.Header.Get("User-Agent")
+
+	service, err := security.GetService(userAgent)
+	if err != nil {
+		return api.Error{Message: err.Error(), Code: http.StatusUnauthorized}
+	}
+
+	if span, ok := tracer.SpanFromContext(r.Context()); ok {
+		span.SetTag("user-agent", userAgent)
+		span.SetTag("service-name", service.Name)
+	}
+
+	tokenErr := security.VerifyToken(s.secretManager, service, requestToken)
+
+	if tokenErr != nil {
+		return api.Error{Message: "Unauthorized: " + tokenErr.Error(), Code: http.StatusUnauthorized}
+	}
+
+	s.metricClient.Incr(
+		"incoming.requests",
+		monitoring.Tag("service-name", service.Name),
+		monitoring.Tag("service-environment", service.Environment),
+	)
+
+	return nil
+}

--- a/api/rest/v1/middleware_security.go
+++ b/api/rest/v1/middleware_security.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AuthWrapper wraps a router to validate the authentication token
-func (s *server) middlewareSecurity(h http.HandlerFunc) http.HandlerFunc {
+func (s *Server) middlewareSecurity(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := s.checkAuth(r)
 		if err != nil {
@@ -32,7 +32,7 @@ func (s *server) middlewareSecurity(h http.HandlerFunc) http.HandlerFunc {
 }
 
 // checkAuth checks if user has proper token + user agent
-func (s *server) checkAuth(r *http.Request) error {
+func (s *Server) checkAuth(r *http.Request) error {
 	requestToken, err := security.GetToken(r.Header.Get("Authorization"))
 	if err != nil {
 		return api.Error{Message: "Use the Bearer {token} authorization scheme", Code: http.StatusUnauthorized}

--- a/api/rest/v1/middleware_security_test.go
+++ b/api/rest/v1/middleware_security_test.go
@@ -41,7 +41,7 @@ func (m *mockedMetricsService) Incr(serviceName string, tags ...string) {
 func TestUnhappyPathCheckAuth(t *testing.T) {
 	m := &mockedMetricsService{}
 	sm := createFakeManager()
-	s := server{
+	s := Server{
 		secretManager: sm,
 		metricClient:  m,
 	}
@@ -72,7 +72,7 @@ func TestUnhappyPathCheckAuth(t *testing.T) {
 func TestHappyPathCheckAuth(t *testing.T) {
 	m := &mockedMetricsService{}
 	sm := createFakeManager()
-	s := server{
+	s := Server{
 		secretManager: sm,
 		metricClient:  m,
 	}

--- a/api/rest/v1/middleware_security_test.go
+++ b/api/rest/v1/middleware_security_test.go
@@ -1,0 +1,92 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kiwicom/iam/internal/security/secrets"
+)
+
+type mockedSecretManager struct {
+	mock.Mock
+}
+
+func (s *mockedSecretManager) GetAppToken(app, environment string) (string, error) {
+	if app == "serviceName" && environment == "environment" {
+		return "valid token", nil
+	}
+	return "", errors.New("wrong token bro")
+}
+
+func (s *mockedSecretManager) GetSetting(app string) (string, error) {
+	return "", nil
+}
+
+func createFakeManager() secrets.SecretManager {
+	return &mockedSecretManager{}
+}
+
+type mockedMetricsService struct {
+	mock.Mock
+}
+
+func (m *mockedMetricsService) Incr(serviceName string, tags ...string) {
+	m.Called(serviceName, tags)
+}
+
+func TestUnhappyPathCheckAuth(t *testing.T) {
+	m := &mockedMetricsService{}
+	sm := createFakeManager()
+	s := server{
+		secretManager: sm,
+		metricClient:  m,
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	err := s.checkAuth(req)
+	assert.Error(t, err, "Should error on missing email")
+
+	req, _ = http.NewRequest("GET", "http://example.com/?email=email@example.com", nil)
+	err = s.checkAuth(req)
+	assert.Error(t, err, "Should error on missing User-Agent")
+
+	req.Header.Set("User-Agent", "serviceName/version (Kiwi.com environment)")
+	err = s.checkAuth(req)
+	assert.Error(t, err, "Should error on missing Authorization header")
+
+	req.Header.Set("Authorization", "invalid token")
+	err = s.checkAuth(req)
+	assert.Error(t, err, "Should error on invalid token schema")
+	m.AssertNotCalled(t, "Incr")
+
+	req.Header.Set("Authorization", "Bearer invalid token")
+	err = s.checkAuth(req)
+	assert.Error(t, err, "Should error on invalid token")
+	m.AssertNotCalled(t, "Incr")
+}
+
+func TestHappyPathCheckAuth(t *testing.T) {
+	m := &mockedMetricsService{}
+	sm := createFakeManager()
+	s := server{
+		secretManager: sm,
+		metricClient:  m,
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/?email=email@example.com", nil)
+
+	req.Header.Set("User-Agent", "serviceName/version (Kiwi.com environment)")
+	err := s.checkAuth(req)
+	assert.Error(t, err, "Should error on missing Authorization header")
+	m.AssertNotCalled(t, "Incr")
+
+	req.Header.Set("Authorization", "Bearer valid token")
+	m.On("Incr", "incoming.requests", []string{"service-name:servicename", "service-environment:environment"})
+	err = s.checkAuth(req)
+	assert.NoError(t, err, "Should not error on valid request token")
+	m.AssertNumberOfCalls(t, "Incr", 1)
+}

--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -6,4 +6,5 @@ import "github.com/gorilla/mux"
 func (s *server) routes() {
 	s.router = mux.NewRouter()
 	s.router.HandleFunc("/", s.handleHello())
+	s.router.HandleFunc("/healthcheck", s.handleHealthcheck())
 }

--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -7,4 +7,5 @@ func (s *server) routes() {
 	s.router = mux.NewRouter()
 	s.router.HandleFunc("/", s.handleHello())
 	s.router.HandleFunc("/healthcheck", s.handleHealthcheck())
+	s.router.HandleFunc("/teams", s.middlewareSecurity(s.handleTeamsGET()))
 }

--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -3,7 +3,7 @@ package rest
 import "github.com/gorilla/mux"
 
 // routes handles registering all routes. All routes should be added here.
-func (s *server) routes() {
+func (s *Server) routes() {
 	s.router = mux.NewRouter()
 	s.router.HandleFunc("/", s.handleHello())
 	s.router.HandleFunc("/healthcheck", s.handleHealthcheck())

--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -1,0 +1,9 @@
+package rest
+
+import "github.com/gorilla/mux"
+
+// routes handles registering all routes. All routes should be added here.
+func (s *server) routes() {
+	s.router = mux.NewRouter()
+	s.router.HandleFunc("/", s.handleHello())
+}

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -4,11 +4,20 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/kiwicom/iam/internal/security/secrets"
 )
+
+type metricService interface {
+	// Incr increments by 1 a metric identified by name.
+	// tags should be in format name:value and can be created with Tag function to escape the values
+	Incr(string, ...string)
+}
 
 // server houses all dependencies and routing of the server
 type server struct {
-	router *mux.Router
+	router        *mux.Router
+	secretManager secrets.SecretManager
+	metricClient  metricService
 }
 
 func newServer() server {

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -22,6 +22,7 @@ type server struct {
 
 func newServer() server {
 	s := server{}
+	s.routes()
 
 	return s
 }

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -1,0 +1,22 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// server houses all dependencies and routing of the server
+type server struct {
+	router *mux.Router
+}
+
+func newServer() server {
+	s := server{}
+
+	return s
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
+}

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/kiwicom/iam/internal/security/secrets"
 )
 

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -4,8 +4,15 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/kiwicom/iam/internal/security/secrets"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+type oktaService interface {
+	GetTeams() (map[string]int, error)
+}
 
 type metricService interface {
 	// Incr increments by 1 a metric identified by name.
@@ -18,6 +25,7 @@ type server struct {
 	router        *mux.Router
 	secretManager secrets.SecretManager
 	metricClient  metricService
+	oktaService   oktaService
 }
 
 func newServer() server {

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -22,21 +22,22 @@ type metricService interface {
 	Incr(string, ...string)
 }
 
-// server houses all dependencies and routing of the server
-type server struct {
+// Server houses all dependencies and routing of the server
+type Server struct {
 	router        *mux.Router
 	secretManager secrets.SecretManager
 	metricClient  metricService
 	oktaService   oktaService
 }
 
-func newServer() server {
-	s := server{}
+// NewServer creates a new instance of server and sets up routes
+func NewServer() *Server {
+	s := Server{}
 	s.routes()
 
-	return s
+	return &s
 }
 
-func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.router.ServeHTTP(w, r)
 }

--- a/api/rest/v1/server_test.go
+++ b/api/rest/v1/server_test.go
@@ -13,7 +13,8 @@ func TestProtectedRoutes(t *testing.T) {
 	srv.routes()
 
 	tests := map[string]int{
-		"/": 200,
+		"/":            200,
+		"/healthcheck": 200,
 	}
 
 	for route, code := range tests {

--- a/api/rest/v1/server_test.go
+++ b/api/rest/v1/server_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProtectedRoutes(t *testing.T) {
-	srv := newServer()
+	srv := NewServer()
 
 	tests := map[string]int{
 		"/":            http.StatusOK,

--- a/api/rest/v1/server_test.go
+++ b/api/rest/v1/server_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestProtectedRoutes(t *testing.T) {
-	srv := server{}
-	srv.routes()
+	srv := newServer()
 
 	tests := map[string]int{
-		"/":            200,
-		"/healthcheck": 200,
+		"/":            http.StatusOK,
+		"/healthcheck": http.StatusOK,
+		"/teams":       http.StatusUnauthorized,
 	}
 
 	for route, code := range tests {
@@ -26,6 +26,5 @@ func TestProtectedRoutes(t *testing.T) {
 		srv.ServeHTTP(w, req)
 
 		assert.Equal(t, code, w.Code)
-
 	}
 }

--- a/api/rest/v1/server_test.go
+++ b/api/rest/v1/server_test.go
@@ -1,0 +1,30 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtectedRoutes(t *testing.T) {
+	srv := server{}
+	srv.routes()
+
+	tests := map[string]int{
+		"/": 200,
+	}
+
+	for route, code := range tests {
+		req, err := http.NewRequest("GET", route, nil)
+		assert.NoError(t, err)
+
+		w := httptest.NewRecorder()
+
+		srv.ServeHTTP(w, req)
+
+		assert.Equal(t, code, w.Code)
+
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getsentry/raven-go v0.2.0
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/protobuf v1.3.2
+	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519
 	github.com/json-iterator/go v1.1.7
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=


### PR DESCRIPTION
- uses server struct instead of the previous way where a lot of dependencies were passed in by arguments
- adds integration test for protected routes
- migrates healthcheck and hello endpoints
- uses mux instead of the julienschmidt package (Mux uses standard http.Handler and doesn't need any extra mux specific types unlike the julienschmidt package)
- migrates /teams endpoint

References #102 