### PR TITLE
feat(okta): add route for getting permissions by user

### DIFF
--- a/api/rest/route_permissions_test.go
+++ b/api/rest/route_permissions_test.go
@@ -22,6 +22,11 @@ func (u *permissionService) GetServicesPermissions(services []string) (map[strin
 	return argsToReturn.Get(0).(map[string]okta.Permissions), argsToReturn.Error(1)
 }
 
+func (u *permissionService) GetUserPermissions(email string, services []string) (map[string][]string, error) {
+	argsToReturn := u.Called(email, services)
+	return argsToReturn.Get(0).(map[string][]string), argsToReturn.Error(1)
+}
+
 func mockPermissionsRoute() (*httprouter.Router, *permissionService) {
 	s := &permissionService{}
 	tracer, _ := monitoring.CreateNewTracingService(monitoring.TracerOptions{
@@ -32,7 +37,7 @@ func mockPermissionsRoute() (*httprouter.Router, *permissionService) {
 	})
 
 	router := httprouter.New()
-	router.GET("/", getServicesPermissions(s, tracer))
+	router.GET("/", getPermissions(s, tracer))
 	return router, s
 }
 
@@ -43,7 +48,7 @@ func mockPermissionsRequest(router http.Handler, method, path string) *httptest.
 	return response
 }
 
-func TestPermissions(t *testing.T) {
+func TestServicePermissions(t *testing.T) {
 	router, s := mockPermissionsRoute()
 
 	// Unhappy paths
@@ -57,7 +62,7 @@ func TestPermissions(t *testing.T) {
 	assert.Equal(t, "invalid email\n", response.Body.String())
 	s.AssertNumberOfCalls(t, "GetServicesPermissions", 0)
 
-	testPermissions := map[string]okta.Permissions{
+	expectedPermissions := map[string]okta.Permissions{
 		"test": {
 			"access": []string{"user1", "user2"},
 			"admin":  []string{"user1"},
@@ -65,14 +70,32 @@ func TestPermissions(t *testing.T) {
 	}
 
 	// Happy path
-	s.On("GetServicesPermissions", []string{"test"}).Return(testPermissions, nil)
+	s.On("GetServicesPermissions", []string{"test"}).Return(expectedPermissions, nil)
 
 	response = mockPermissionsRequest(router, "GET", "/?services=test")
 	assert.Equal(t, 200, response.Code, "Returns 200 on success")
 
-	responsePermissions := make(map[string]okta.Permissions)
-	_ = json.Unmarshal(response.Body.Bytes(), &responsePermissions)
+	actualPermissions := make(map[string]okta.Permissions)
+	_ = json.Unmarshal(response.Body.Bytes(), &actualPermissions)
 
-	assert.Equal(t, testPermissions, responsePermissions)
+	assert.Equal(t, expectedPermissions, actualPermissions)
 	s.AssertNumberOfCalls(t, "GetServicesPermissions", 1)
+	s.AssertNumberOfCalls(t, "GetUserPermissions", 0)
+}
+
+func TestUserPermissions(t *testing.T) {
+	router, s := mockPermissionsRoute()
+
+	expectedPermissions := map[string][]string{"test": {"access", "admin"}}
+	s.On("GetUserPermissions", "user@test.com", []string{"test"}).Return(expectedPermissions, nil)
+
+	response := mockPermissionsRequest(router, "GET", "/?services=test&email=user@test.com")
+	assert.Equal(t, 200, response.Code, "Returns 200 on success")
+
+	actualPermissions := make(map[string][]string)
+	_ = json.Unmarshal(response.Body.Bytes(), &actualPermissions)
+
+	assert.Equal(t, expectedPermissions, actualPermissions)
+	s.AssertNumberOfCalls(t, "GetUserPermissions", 1)
+	s.AssertNumberOfCalls(t, "GetServicePermissions", 0)
 }

--- a/api/rest/router.go
+++ b/api/rest/router.go
@@ -61,7 +61,7 @@ func CreateRouter(
 
 	addEndpoint("/v1/groups", getGroups(oktaClient))
 
-	addEndpoint("/v1/permissions", getServicesPermissions(oktaClient, tracer))
+	addEndpoint("/v1/permissions", getPermissions(oktaClient, tracer))
 
 	router.PanicHandler = panicHandler
 

--- a/internal/services/okta/permissions.go
+++ b/internal/services/okta/permissions.go
@@ -81,3 +81,32 @@ func (c *Client) GetServicesPermissions(services []string) (map[string]Permissio
 
 	return permissions, nil
 }
+
+func stringInSlice(str string, slice []string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+// GetUserPermissions returns permissions for the specified user for the
+// requested services.
+func (c *Client) GetUserPermissions(email string, services []string) (map[string][]string, error) {
+	allPermissions, err := c.GetServicesPermissions(services)
+	if err != nil {
+		return nil, err
+	}
+
+	userPermissions := make(map[string][]string)
+	for _, service := range services {
+		for permission, users := range allPermissions[service] {
+			if stringInSlice(email, users) {
+				userPermissions[service] = append(userPermissions[service], permission)
+			}
+		}
+	}
+
+	return userPermissions, nil
+}


### PR DESCRIPTION
Closes #121 

In the end I kept email as user ID as discussed internally. The reason for this is to not add yet another ID for users. 