### PR TITLE
feat: Add github actions for Revive and GolangCI-Lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,11 +8,14 @@ jobs:
   build:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [1.12, 1.13]
     steps:
-      - name: Set up Go
+      - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -25,3 +25,28 @@ jobs:
         uses: docker://quay.io/goswagger/swagger
         with:
           args: validate ./api/swagger.yml
+  golang-ci-lint:
+    name: Lint the project using GolangCI Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Run GolangCI-Lint
+        uses: matoous/golangci-lint-action@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .golangci.yml
+  revive-lint:
+    name: Lint the project using Revive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v1
+
+      - name: Run Revive
+        uses: docker://morphy/revive-action:v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .revive.toml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,9 @@ linters-settings:
     suggest-new: true
   misspell:
     locale: US
+  funlen: # be little bit more permissive then the default values
+    lines: 70
+    statements: 60
 
 linters:
   enable-all: true
@@ -41,6 +44,7 @@ linters:
     # prealloc is not recommended by `golangci-lint` developers.
     - prealloc
     - gochecknoglobals
+    - wsl
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,9 @@ linters:
   disable:
     # prealloc is not recommended by `golangci-lint` developers.
     - prealloc
+    # global values are used on many places but meaningfully, this makes more sense then adding multiple ignore comments
     - gochecknoglobals
+    # wsl *forces* you to use spaces on many places and makes the code very very long (unnecessarily)
     - wsl
 
 issues:

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,135 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+
+# confidence <= 0.2 generate a lot of errors from package-comments rule. It marks files that do not contain
+# package-level comments as a warning irrespective of existing package-level coment in one file.
+confidence = 0.25
+errorCode = 1
+warningCode = 1
+
+# Rules block.
+# ⚠ Make sure to sort rules alpabetically for readability! ⚠
+
+# argument-limit rule is setting up a maximum number of parameters that can be passed to the functions/methods.
+[rule.argument-limit]
+  arguments = [5]
+
+# atomic rule checks for commonly mistaken usages of the sync/atomic package.
+[rule.atomic]
+
+# blank-imports rule disallows blank imports.
+[rule.blank-imports]
+
+# bool-literal-in-expr suggests removing boolean literals from logic expressions like `bar == true`, `arg == false`,
+# `r != true`, `false && boolExpr` and `boolExpr || true`.
+[rule.bool-literal-in-expr]
+
+# constant-logical-expr rule warns on constant logical expressions, like `name == name`.
+[rule.constant-logical-expr]
+
+# context-as-argument rule makes sure that context.Context is the first argument of a function.
+[rule.context-as-argument]
+
+# context-keys-type rule disallows the usage of basic types in context.WithValue
+[rule.context-keys-type]
+
+# confusing-naming rule warns on methods with names that differ only by capitalization.
+[rule.confusing-naming]
+
+# confusing-results rule suggests to name potentially confusing function results.
+[rule.confusing-results]
+
+# cyclomatic rule sets restriction for maximum Cyclomatic complexity.
+[rule.cyclomatic]
+  arguments = [15]
+
+# deep-exit rule looks for program exits in funcs other than `main()` or `init()`.
+[rule.deep-exit]
+
+# dot-imports rule forbids `.` imports.
+[rule.dot-imports]
+
+# empty-block warns on empty code blocks.
+[rule.empty-block]
+
+# error-return rule ensure that the error return parameter is the last.
+[rule.error-return]
+
+# error-strings rule ensure conventions around error strings.
+[rule.error-strings]
+
+# error-naming rule ensure naming of error variables (has `Err` or `err` prefix).
+[rule.error-naming]
+
+# errorf rule warns on usage errors.New(fmt.Sprintf()) instead of fmt.Errorf()
+[rule.errorf]
+
+# exported rule ensure naming and commenting conventions on exported symbols.
+[rule.exported]
+
+# flag-parameter rule warns on boolean parameters that create a control coupling.
+[rule.flag-parameter]
+
+# get-return rule warns on getters that do not yield any result.
+[rule.get-return]
+
+# if-return rule warns redundant if when returning an error.
+[rule.if-return]
+
+# increment-decrement rule forces to use `i++` and `i--` instead of `i += 1` and `i -= 1`.
+[rule.increment-decrement]
+
+# indent-error-flow rule prevents redundant else statements.
+[rule.indent-error-flow]
+
+# modifies-value-receiver warns on assignments to value-passed method receivers.
+[rule.modifies-value-receiver]
+
+# package-comments rule ensures package commenting conventions.
+[rule.package-comments]
+
+# range rule prevents redundant variables when iterating over a collection.
+[rule.range]
+
+# range-val-in-closure warns if range value is used in a closure dispatched as goroutine.
+[rule.range-val-in-closure]
+
+# receiver-naming ensures conventions around the naming of receivers.
+[rule.receiver-naming]
+
+# redefines-builtin-id warns on redefinitions of built-in (constants, variables, function and types) identifiers,
+# like `true := "false"` etc.
+[rule.redefines-builtin-id]
+
+# rule.superfluous-else prevents redundant else statements (extends indent-error-flow). Checks for `if-then-else`where
+# the then block ends with branching statement like `continue`, `break`, or `goto`.
+[rule.superfluous-else]
+
+# rule.struct-tag checks common struct tags like `json`, `xml`, `yaml`.
+[rule.struct-tag]
+
+# time-naming rule conventions around the naming of time variables. Like not to use unit suffixes (sec, min etc.) in
+# naming variables of type `time.Time` or `time.Duration`.
+[rule.time-naming]
+
+# unexported-return rule warns when a public return is from unexported type.
+[rule.unexported-return]
+
+# unnecessary-stmt  suggests removing or simplifying unnecessary statements like breaks at the end of cases or return at
+# the end of bodies of functions returning nothing.
+[rule.unnecessary-stmt]
+
+# unreachable-code rule warns on the unreachable code.
+[rule.unreachable-code]
+
+# unused-parameter rule suggests to rename or remove unused function parameters.
+[rule.unused-parameter]
+
+# var-declaration rule reduces redundancies around variable declaration.
+[rule.var-declaration]
+
+# var-naming checks naming rules.
+[rule.var-naming]
+
+# waitgroup-by-value rule warns on functions taking `sync.WaitGroup` as a by-value parameter.
+[rule.waitgroup-by-value]

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,16 @@ define log_success
 	@printf "$(color_green)$(1)$(color_off)\n"
 endef
 
-lint:
+lint: revive-lint golangci-lint
+
+revive-lint:
+	$(call log_info, Running revive linter)
+	revive -config .revive.toml ./...
+	$(call log_success,Linting with revive linter succeeded!)
+
+golangci-lint:
 	$(call log_info, Running golangci-lint)
-	golangci-lint run internal/...
+	golangci-lint run ./...
 	$(call log_success,Linting with golangci-lint succeeded!)
 
 go-mod-tidy:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endef
 
 lint:
 	$(call log_info, Running golangci-lint)
-	golangci-lint run
+	golangci-lint run internal/...
 	$(call log_success,Linting with golangci-lint succeeded!)
 
 go-mod-tidy:

--- a/api/grpc/server.go
+++ b/api/grpc/server.go
@@ -25,7 +25,7 @@ func CreateServer(userServiceClient userDataService) (*Server, error) {
 }
 
 // User returns a single user based on email
-func (s *Server) User(ctx context.Context, in *pb.UserRequest) (*pb.UserResponse, error) {
+func (s *Server) User(_ context.Context, in *pb.UserRequest) (*pb.UserResponse, error) {
 	user, userErr := s.userService.GetUser(in.Email)
 	if userErr != nil {
 		return nil, userErr

--- a/api/rest/middleware_deprecation_test.go
+++ b/api/rest/middleware_deprecation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//revive:disable // for testing purposes
 func createRouter() *httprouter.Router {
 	router := httprouter.New()
 	router.GET("/", addDeprecationWarning(sayHello))

--- a/api/rest/middleware_deprecation_test.go
+++ b/api/rest/middleware_deprecation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//revive:disable // for testing purposes
+// revive:disable:confusing-naming createRouter is for testing, CreateRouter is used normally
 func createRouter() *httprouter.Router {
 	router := httprouter.New()
 	router.GET("/", addDeprecationWarning(sayHello))

--- a/api/rest/panic_handler.go
+++ b/api/rest/panic_handler.go
@@ -10,7 +10,7 @@ import (
 )
 
 // panicHandler prevents the server crashing due to unhandled panics
-func panicHandler(w http.ResponseWriter, r *http.Request, err interface{}) {
+func panicHandler(w http.ResponseWriter, _ *http.Request, err interface{}) {
 	apiError, castingOk := err.(api.Error)
 	if castingOk {
 		raven.CaptureError(apiError, nil)
@@ -22,5 +22,5 @@ func panicHandler(w http.ResponseWriter, r *http.Request, err interface{}) {
 	if errorType, castingOk := err.(error); castingOk {
 		raven.CaptureError(errorType, nil)
 	}
-	log.Panic(err)
+	log.Println("[ERROR]", err)
 }

--- a/api/rest/route_healthcheck.go
+++ b/api/rest/route_healthcheck.go
@@ -8,7 +8,7 @@ import (
 )
 
 // healthcheck is a route for healthcheck
-func healthcheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func healthcheck(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	var message = "Ok"
 	_, err := w.Write([]byte(message))
 

--- a/api/rest/route_hello.go
+++ b/api/rest/route_hello.go
@@ -8,7 +8,7 @@ import (
 )
 
 // sayHello is a route for HelloWorld
-func sayHello(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func sayHello(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	message := "42"
 	_, err := w.Write([]byte(message))
 	if err != nil {

--- a/api/rest/route_permissions_test.go
+++ b/api/rest/route_permissions_test.go
@@ -41,6 +41,7 @@ func mockPermissionsRoute() (*httprouter.Router, *permissionService) {
 	return router, s
 }
 
+// nolint:unparam // even though method is currently always "GET" we might decide to use other methods in the future
 func mockPermissionsRequest(router http.Handler, method, path string) *httptest.ResponseRecorder {
 	response := httptest.NewRecorder()
 	request, _ := http.NewRequest(method, path, nil)

--- a/api/rest/route_user.go
+++ b/api/rest/route_user.go
@@ -116,6 +116,8 @@ func validateUsersParams(rawQuery string) (map[string]string, error) {
 	return params, nil
 }
 
+//revive:disable:flag-parameter
+
 // formatUser converts the given user to map and keeps or removes the
 // permissions field based on the withPermissions parameter.
 func formatUser(s *okta.User, withPermissions bool) (map[string]interface{}, error) {

--- a/api/rest/router.go
+++ b/api/rest/router.go
@@ -22,8 +22,7 @@ type metricService interface {
 }
 
 // CreateRouter creates a new router instance
-//revive:disable:confusing-naming createRouter is for testing
-func CreateRouter(
+func CreateRouter( // revive:disable-line:confusing-naming createRouter is for testing
 	serviceName string,
 	oktaClient *okta.Client,
 	secretManager secrets.SecretManager,

--- a/api/rest/router.go
+++ b/api/rest/router.go
@@ -22,6 +22,7 @@ type metricService interface {
 }
 
 // CreateRouter creates a new router instance
+//revive:disable:confusing-naming createRouter is for testing
 func CreateRouter(
 	serviceName string,
 	oktaClient *okta.Client,

--- a/api/rest/security_middleware_test.go
+++ b/api/rest/security_middleware_test.go
@@ -22,7 +22,7 @@ func (s *mockedSecretManager) GetAppToken(app, environment string) (string, erro
 	return "", errors.New("wrong token bro")
 }
 
-func (s *mockedSecretManager) GetSetting(app string) (string, error) {
+func (s *mockedSecretManager) GetSetting(_ string) (string, error) {
 	return "", nil
 }
 

--- a/api/rest/v1/middleware_security_test.go
+++ b/api/rest/v1/middleware_security_test.go
@@ -22,7 +22,7 @@ func (s *mockedSecretManager) GetAppToken(app, environment string) (string, erro
 	return "", errors.New("wrong token bro")
 }
 
-func (s *mockedSecretManager) GetSetting(app string) (string, error) {
+func (s *mockedSecretManager) GetSetting(_ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,6 +152,7 @@ func capturePanic(f func()) {
 	f()
 }
 
+//nolint:funlen // might need some refactoring in the future but is otherwise is readable
 func main() {
 	cfg.InitEnv()
 

--- a/internal/security/secrets/vault.go
+++ b/internal/security/secrets/vault.go
@@ -24,7 +24,7 @@ type VaultManager struct {
 	namespace string
 }
 
-var requiredPrefix = "/secret"
+const requiredPrefix = "/secret"
 
 // CreateNewVaultClient create a new client to connect to Vault
 func CreateNewVaultClient(address, token, namespace string) (*VaultManager, error) {

--- a/internal/services/okta/controller.go
+++ b/internal/services/okta/controller.go
@@ -219,7 +219,6 @@ func (c *Client) SyncGroups() {
 			raven.CaptureError(err, nil)
 			return
 		}
-
 	}
 
 	if err = c.cache.Set("groups-sync-timestamp", syncStart, cfg.Expirations.GroupsLastSync); err != nil {

--- a/internal/services/okta/http.go
+++ b/internal/services/okta/http.go
@@ -69,7 +69,7 @@ func defaultFetcher(userAgent string, metrics *monitoring.Metrics) func(req Requ
 		httpReq.Header.Set("Authorization", req.Token)
 
 		metrics.Incr("outgoing.requests", monitoring.Tag("url", req.URL))
-		httpRes, err := httpClient.Do(httpReq)
+		httpRes, err := httpClient.Do(httpReq) //nolint:bodyclose // body is closed on reading either to string or JSON
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/okta/teams_test.go
+++ b/internal/services/okta/teams_test.go
@@ -13,7 +13,7 @@ type mockCache struct {
 	data map[string]interface{}
 }
 
-func (c *mockCache) Set(key string, value interface{}, ttl time.Duration) error {
+func (c *mockCache) Set(key string, value interface{}, _ time.Duration) error {
 	c.data[key] = value
 	return nil
 }

--- a/internal/storage/lock_test.go
+++ b/internal/storage/lock_test.go
@@ -22,10 +22,9 @@ type mockCache struct {
 // nolint: staticcheck
 func (c *mockCache) Get(key string, value interface{}) error {
 	v, ok := c.data[key]
-	if ok == false || time.Since(v.expiration) > 0 {
+	if !ok || time.Since(v.expiration) > 0 {
 		delete(c.data, key)
 		return ErrNotFound
-
 	}
 	// ineffective assignment of `value`
 	// nolint: ineffassign

--- a/internal/storage/redis_cache.go
+++ b/internal/storage/redis_cache.go
@@ -133,7 +133,6 @@ func (c *RedisCache) MSet(pairs map[string]interface{}, ttl time.Duration) error
 			log.Println("Error setting keys expiration")
 			raven.CaptureError(expErr, nil)
 		}
-
 	}
 
 	return err


### PR DESCRIPTION
Add Github Actions and Makefile Targets for _GolangCI lint_ and _Revive_ lint, refactor the `lint` makefile target to do both. This should make it easier (after @fallion figures out how to handle automatic updates to Github actions) to maintain this as a Github repo without many external dependencies.

Signed-off-by: Matous Dzivjak <matousdzivjak@gmail.com>