### PR TITLE
chore(api): expose struct fields

### DIFF
--- a/api/rest/v1/handle_teams.go
+++ b/api/rest/v1/handle_teams.go
@@ -9,7 +9,7 @@ import (
 
 func (s *Server) handleTeamsGET() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		teams, err := s.oktaService.GetTeams()
+		teams, err := s.OktaService.GetTeams()
 		if err != nil {
 			http.Error(w, "Service unavailable", http.StatusInternalServerError)
 			return

--- a/api/rest/v1/handle_teams_test.go
+++ b/api/rest/v1/handle_teams_test.go
@@ -13,7 +13,7 @@ func TestInternalError(t *testing.T) {
 	s := Server{}
 	errMessage := "internal error that shouldn't be exposed"
 	tg := &mockOktaService{}
-	s.oktaService = tg
+	s.OktaService = tg
 	tg.On("GetTeams").Return(map[string]int{}, errors.New(errMessage))
 
 	request, _ := http.NewRequest("GET", "/", nil)
@@ -32,7 +32,7 @@ func TestGetTeams(t *testing.T) {
 	s := Server{}
 	tg := &mockOktaService{}
 	tg.On("GetTeams").Return(map[string]int{"team1": 3, "team2": 1, "team3": 1}, nil)
-	s.oktaService = tg
+	s.OktaService = tg
 
 	request, _ := http.NewRequest("GET", "/", nil)
 

--- a/api/rest/v1/handle_user.go
+++ b/api/rest/v1/handle_user.go
@@ -32,9 +32,9 @@ func (s *Server) handleUserGET() http.HandlerFunc {
 
 		// getUser just wraps GetUser in tracing
 		getUser := func() (*okta.User, error) {
-			span, _ := s.tracer.StartSpanWithContext(r.Context(), "user-data", "okta-controller", "http")
-			defer s.tracer.FinishSpan(span)
-			oktaUser, err := s.oktaService.GetUser(email)
+			span, _ := s.Tracer.StartSpanWithContext(r.Context(), "user-data", "okta-controller", "http")
+			defer s.Tracer.FinishSpan(span)
+			oktaUser, err := s.OktaService.GetUser(email)
 
 			return &oktaUser, err
 		}
@@ -50,9 +50,9 @@ func (s *Server) handleUserGET() http.HandlerFunc {
 
 		// addPermissions just wraps AddPermissions with tracing
 		addPermissions := func() error {
-			span, _ := s.tracer.StartSpanWithContext(r.Context(), "permissions", "okta-controller", "http")
-			defer s.tracer.FinishSpan(span)
-			permErr := s.oktaService.AddPermissions(oktaUser, service.Name)
+			span, _ := s.Tracer.StartSpanWithContext(r.Context(), "permissions", "okta-controller", "http")
+			defer s.Tracer.FinishSpan(span)
+			permErr := s.OktaService.AddPermissions(oktaUser, service.Name)
 
 			return permErr
 		}

--- a/api/rest/v1/handle_user_test.go
+++ b/api/rest/v1/handle_user_test.go
@@ -21,14 +21,14 @@ var testUser = okta.User{
 
 func setupServer() *Server {
 	s := &Server{}
-	tracer, _ := monitoring.CreateNewTracingService(monitoring.TracerOptions{
+	Tracer, _ := monitoring.CreateNewTracingService(monitoring.TracerOptions{
 		ServiceName: "kiwi-iam",
 		Environment: "test",
 		Port:        "8126",
 		Host:        "test",
 	})
 
-	s.tracer = tracer
+	s.Tracer = Tracer
 
 	return s
 }
@@ -38,7 +38,7 @@ func TestMissingQuery(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/", nil)
 	response := httptest.NewRecorder()
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 
@@ -56,7 +56,7 @@ func TestWrongEmail(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/?email=testest", nil)
 	response := httptest.NewRecorder()
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 
@@ -74,7 +74,7 @@ func TestMissingUserAgent(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/?email=test@test.com", nil)
 	response := httptest.NewRecorder()
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 	handler.ServeHTTP(response, request)
@@ -93,7 +93,7 @@ func TestHappyPathWithPermissions(t *testing.T) {
 	request.Header.Set("User-Agent", "service/0 (Kiwi.com test)")
 	response := httptest.NewRecorder()
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 	userService.On("GetUser", "test@test.com").Return(testUser, nil)
@@ -126,7 +126,7 @@ func TestHappyPathNoPermissions(t *testing.T) {
 
 		userService := &mockOktaService{}
 		server := setupServer()
-		server.oktaService = userService
+		server.OktaService = userService
 
 		handler := server.handleUserGET()
 		userService.On("GetUser", "test@test.com").Return(testUser, nil)
@@ -158,7 +158,7 @@ func TestControllerFailurePath(t *testing.T) {
 
 	userService := &mockOktaService{}
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 	userService.On("GetUser", "bs@test.com").Return(okta.User{}, errors.New("boom"))
@@ -178,7 +178,7 @@ func TestNotFoundPath(t *testing.T) {
 
 	userService := &mockOktaService{}
 	server := setupServer()
-	server.oktaService = userService
+	server.OktaService = userService
 
 	handler := server.handleUserGET()
 	userService.On("GetUser", "notfound@test.com").Return(okta.User{}, okta.ErrUserNotFound)

--- a/api/rest/v1/middleware_security.go
+++ b/api/rest/v1/middleware_security.go
@@ -4,11 +4,10 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-
 	"github.com/kiwicom/iam/api"
 	"github.com/kiwicom/iam/internal/monitoring"
 	"github.com/kiwicom/iam/internal/security"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // AuthWrapper wraps a router to validate the authentication token
@@ -49,13 +48,13 @@ func (s *Server) checkAuth(r *http.Request) error {
 		span.SetTag("service-name", service.Name)
 	}
 
-	tokenErr := security.VerifyToken(s.secretManager, service, requestToken)
+	tokenErr := security.VerifyToken(s.SecretManager, service, requestToken)
 
 	if tokenErr != nil {
 		return api.Error{Message: "Unauthorized: " + tokenErr.Error(), Code: http.StatusUnauthorized}
 	}
 
-	s.metricClient.Incr(
+	s.MetricClient.Incr(
 		"incoming.requests",
 		monitoring.Tag("service-name", service.Name),
 		monitoring.Tag("service-environment", service.Environment),

--- a/api/rest/v1/middleware_security_test.go
+++ b/api/rest/v1/middleware_security_test.go
@@ -42,8 +42,8 @@ func TestUnhappyPathCheckAuth(t *testing.T) {
 	m := &mockedMetricsService{}
 	sm := createFakeManager()
 	s := Server{
-		secretManager: sm,
-		metricClient:  m,
+		SecretManager: sm,
+		MetricClient:  m,
 	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -73,8 +73,8 @@ func TestHappyPathCheckAuth(t *testing.T) {
 	m := &mockedMetricsService{}
 	sm := createFakeManager()
 	s := Server{
-		secretManager: sm,
-		metricClient:  m,
+		SecretManager: sm,
+		MetricClient:  m,
 	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/?email=email@example.com", nil)

--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -4,9 +4,9 @@ import "github.com/gorilla/mux"
 
 // routes handles registering all routes. All routes should be added here.
 func (s *Server) routes() {
-	s.router = mux.NewRouter()
-	s.router.HandleFunc("/", s.handleHello())
-	s.router.HandleFunc("/healthcheck", s.handleHealthcheck())
-	s.router.HandleFunc("/teams", s.middlewareSecurity(s.handleTeamsGET()))
-	s.router.HandleFunc("/user", s.middlewareSecurity(s.handleUserGET()))
+	s.Router = mux.NewRouter()
+	s.Router.HandleFunc("/", s.handleHello())
+	s.Router.HandleFunc("/healthcheck", s.handleHealthcheck())
+	s.Router.HandleFunc("/teams", s.middlewareSecurity(s.handleTeamsGET()))
+	s.Router.HandleFunc("/user", s.middlewareSecurity(s.handleUserGET()))
 }

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -28,11 +28,11 @@ type metricService interface {
 
 // Server houses all dependencies and routing of the server
 type Server struct {
-	router        *mux.Router
-	secretManager secrets.SecretManager
-	metricClient  metricService
-	oktaService   oktaService
-	tracer        *monitoring.Tracer
+	Router        *mux.Router
+	SecretManager secrets.SecretManager
+	MetricClient  metricService
+	OktaService   oktaService
+	Tracer        *monitoring.Tracer
 }
 
 // NewServer creates a new instance of server and sets up routes
@@ -44,5 +44,5 @@ func NewServer() *Server {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.router.ServeHTTP(w, r)
+	s.Router.ServeHTTP(w, r)
 }


### PR DESCRIPTION
In order to set dependencies in main.go these fields need to be exposed.