### PR TITLE
feat(api): use datadog tracing mux router

### DIFF
--- a/api/rest/v1/routes.go
+++ b/api/rest/v1/routes.go
@@ -1,10 +1,10 @@
 package rest
 
-import "github.com/gorilla/mux"
+import tracingRouter "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 
 // routes handles registering all routes. All routes should be added here.
 func (s *Server) routes() {
-	s.Router = mux.NewRouter()
+	s.Router = tracingRouter.NewRouter(tracingRouter.WithServiceName(s.ServiceName))
 	s.Router.HandleFunc("/", s.handleHello())
 	s.Router.HandleFunc("/healthcheck", s.handleHealthcheck())
 	s.Router.HandleFunc("/teams", s.middlewareSecurity(s.handleTeamsGET()))

--- a/api/rest/v1/server.go
+++ b/api/rest/v1/server.go
@@ -3,9 +3,8 @@ package rest
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	jsoniter "github.com/json-iterator/go"
+	tracingRouter "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 
 	"github.com/kiwicom/iam/internal/monitoring"
 	"github.com/kiwicom/iam/internal/security/secrets"
@@ -28,11 +27,13 @@ type metricService interface {
 
 // Server houses all dependencies and routing of the server
 type Server struct {
-	Router        *mux.Router
+	Router        *tracingRouter.Router
 	SecretManager secrets.SecretManager
 	MetricClient  metricService
 	OktaService   oktaService
 	Tracer        *monitoring.Tracer
+	// ServiceName is used for tracing purposes
+	ServiceName string
 }
 
 // NewServer creates a new instance of server and sets up routes

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getsentry/raven-go v0.2.0
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/golang/protobuf v1.3.2
-	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519
 	github.com/json-iterator/go v1.1.8
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
Until the contrib version of datadog can be replaced by our own custom middleware this seems to be the best option.