### PR TITLE
fix(e2e): update version of git in Venom image

### DIFF
--- a/tests/e2e/venom/Dockerfile
+++ b/tests/e2e/venom/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.12.9-alpine3.9
 
 RUN apk add --no-cache \
-    git~=2.20.1 \
+    git~=2.20.2 \
     autoconf~=2.69 \
     libtool~=2.4.6 \
     curl~=7.64.0 \


### PR DESCRIPTION
Seems alpine pulled the older version.