### PR TITLE
fix: Fix TLS server config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -252,7 +252,7 @@ func main() {
 
 	s, _ := grpcAPI.CreateServer(oktaClient)
 
-	creds, err := credentials.NewClientTLSFromFile(iamConfig.GRPCCertFile, iamConfig.GRPCKeyFile)
+	creds, err := credentials.NewServerTLSFromFile(iamConfig.GRPCCertFile, iamConfig.GRPCKeyFile)
 	if err != nil {
 		log.Println("TLS disabled on GRPC:", err)
 		raven.CaptureError(err, nil)


### PR DESCRIPTION
TLS configuration on server was previously
wrongly initialized as client TLS config so
it didn't work and failed with cryptic
TLS internal server error message.
Fix it.

Signed-off-by: Matous Dzivjak <matousdzivjak@gmail.com>