### PR TITLE
fix(okta): fix incorrect group membership syncing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,7 +196,7 @@ func main() {
 	cache := storage.NewRedisCache(
 		storageConfig.RedisHost,
 		storageConfig.RedisPort,
-		2,
+		3,
 	)
 	lock := storage.NewLockManager(
 		cache,

--- a/internal/services/okta/groups.go
+++ b/internal/services/okta/groups.go
@@ -44,12 +44,6 @@ func (c *Client) fetchGroups(userID, since string) ([]Group, error) {
 	}
 
 	var allGroups []Group
-	var resources []struct {
-		ID                    string
-		Profile               oktaGroupProfile
-		LastMembershipUpdated time.Time
-		LastFetched           time.Time
-	}
 
 	responses, err := c.fetchPagedResource(url + filter)
 	if err != nil {
@@ -57,6 +51,13 @@ func (c *Client) fetchGroups(userID, since string) ([]Group, error) {
 	}
 
 	for _, response := range responses {
+		var resources []struct {
+			ID                    string
+			Profile               oktaGroupProfile
+			LastMembershipUpdated time.Time
+			LastFetched           time.Time
+		}
+
 		jsonErr := json.UnmarshalFromString(response, &resources)
 		if jsonErr != nil {
 			return nil, jsonErr

--- a/tests/e2e/nginx/mocks/groups/index.json
+++ b/tests/e2e/nginx/mocks/groups/index.json
@@ -39,8 +39,8 @@
     "objectClass": ["okta:user_group"],
     "type": "OKTA_GROUP",
     "profile": {
-      "name": "iam-venom.credit-card.create",
-      "description": "Create credit cards."
+      "name": "iam-othergroup.access.admin",
+      "description": "Access admin panel."
     },
     "_links": {
       "logo": [
@@ -71,8 +71,8 @@
     "objectClass": ["okta:user_group"],
     "type": "OKTA_GROUP",
     "profile": {
-      "name": "iam-othergroup.access.admin",
-      "description": "Access admin panel."
+      "name": "iam-venom.credit-card.create",
+      "description": "Create credit cards."
     },
     "_links": {
       "logo": [

--- a/tests/e2e/venom/grpc_client_test.yml
+++ b/tests/e2e/venom/grpc_client_test.yml
@@ -69,6 +69,7 @@ testcases:
           - result.systemoutjson.boocsek.skills.skills0 ShouldEqual skill1
           - result.systemoutjson.boocsek.skills.skills1 ShouldEqual skill2
           - result.systemoutjson.permissions.permissions0 ShouldEqual credit-card.create
+          - result.systemoutjson.permissions.permissions1 ShouldNotExist
   - name: Returns error for missing user
     steps:
       - type: grpc

--- a/tests/e2e/venom/http_client_test.yml
+++ b/tests/e2e/venom/http_client_test.yml
@@ -87,6 +87,7 @@ testcases:
           - result.bodyjson.teammembership.teammembership0 ShouldEqual "Engineering/Regular/Test"
 
           - result.bodyjson.permissions.permissions0 ShouldEqual credit-card.create
+          - result.bodyjson.permissions.permissions1 ShouldNotExist
           - result.statuscode ShouldEqual 200
   - name: Test getting existing user with deprecated token scheme
     steps:


### PR DESCRIPTION
When synchronising group memberships from Okta, in some cases permissions were stored to unrelated services. This happened because the `cachedGroupMemberships` map was reused for all services. 

As a result clients received user permissions for unrelated services.